### PR TITLE
Add a PagingController constructor to use an existing PaginatorState

### DIFF
--- a/lib/src/core/paging_controller.dart
+++ b/lib/src/core/paging_controller.dart
@@ -31,6 +31,16 @@ class PagingController<PageKeyType, ItemType>
           PagingState<PageKeyType, ItemType>(nextPageKey: firstPageKey),
         );
 
+  /// Creates a controller with an existing [PagingState].
+  ///
+  /// In this case, [firstPageKey] should be the key that is associated with the
+  /// first page of the existing state, to be used in [refresh].
+  PagingController.withValue(
+    PagingState<PageKeyType, ItemType> value, {
+    @required this.firstPageKey,
+    this.invisibleItemsThreshold,
+  }) : super(value);
+
   ObserverList<PagingStatusListener> _statusListeners =
       ObserverList<PagingStatusListener>();
 


### PR DESCRIPTION
I cache a paginated list in a globally accessible BLoC that can contain data when the pagination widget is built.

At the moment, a controller can be created like so in `initState()` to do this:

```dart
_controller = PagingController(firstPageKey: 0);
_controller.value = PaginatorState(...);
```

This, however, creates a useless `PaginatorState` at the time of construction that's immediately discarded in the next line.
This PR adds a constructor to bypass this, reducing strain on the CPU and garbage collector.

```dart
_controller = PagingController.withValue(
  PaginatorState(...),
  firstPageKey: 0,
);
```