### PR TITLE
Add updatePagingState to pagingController with copyWith

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,7 +129,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.3.0+1"
   intl:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.6"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/core/paging_controller.dart
+++ b/lib/src/core/paging_controller.dart
@@ -11,6 +11,10 @@ typedef PagingStatusListener = void Function(
   PagingStatus status,
 );
 
+typedef ChangePagingState<PageKeyType, ItemType>
+    = PagingState<PageKeyType, ItemType> Function(
+        PagingState<PageKeyType, ItemType>);
+
 /// A controller for a paged widget.
 ///
 /// If you modify the [itemList], [error] or [nextPageKey] properties, the
@@ -99,6 +103,9 @@ class PagingController<PageKeyType, ItemType>
 
     super.value = newValue;
   }
+
+  void updatePagingState(ChangePagingState<PageKeyType, ItemType> update) =>
+      value = update(value);
 
   /// Appends [newItems] to the previously loaded ones and replaces
   /// the next page's key.

--- a/lib/src/model/paging_state.dart
+++ b/lib/src/model/paging_state.dart
@@ -1,11 +1,12 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+
 import 'package:infinite_scroll_pagination/src/model/paging_status.dart';
 
 /// The current item's list, error, and next page key state for a paginated
 /// widget.
-@immutable
-class PagingState<PageKeyType, ItemType> {
+class PagingState<PageKeyType, ItemType> extends Equatable {
   const PagingState({
     this.nextPageKey,
     this.itemList,
@@ -88,4 +89,7 @@ class PagingState<PageKeyType, ItemType> {
   bool get _hasSubsequentPageError => _isListingUnfinished && _hasError;
 
   bool get _isEmpty => _itemCount != null && _itemCount == 0;
+
+  @override
+  List<Object> get props => [itemList, error, nextPageKey];
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0-nullsafety.3"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.6"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   sliver_tools: ^0.1.10+1
+  equatable: ^1.2.6
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: infinite_scroll_pagination
 description: Lazily load and display pages of items as the user scrolls down your screen.
-version: 2.3.0
+version: 2.3.0+1
 homepage: https://github.com/EdsonBueno/infinite_scroll_pagination
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   sliver_tools: ^0.1.10+1
-  equatable: ^1.2.6
+  equatable: <2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I added copyWith to PagingState class, and updatePagingState to pagingController. the current solution of changing directly .value is not good, copyWith made it much simpler: 
```
pagingController.updatePagingState(
    (v) => v.copyWith(
         itemList: v.itemList..removeWhere((u) => u.id == userId),
    ),
);
```
