### PR TITLE
refactor: uses proper widget for key setup

### DIFF
--- a/lib/src/ui/paged_sliver_builder.dart
+++ b/lib/src/ui/paged_sliver_builder.dart
@@ -224,7 +224,7 @@ class _PagedSliverBuilderState<PageKeyType, ItemType>
             if (_builderDelegate.animateTransitions) {
               return SliverAnimatedSwitcher(
                 duration: _builderDelegate.transitionDuration,
-                child: Container(
+                child: KeyedSubtree(
                   // The `ObjectKey` makes it possible to differentiate
                   // transitions between same Widget types, e.g., ongoing to
                   // completed.


### PR DESCRIPTION
Because `KeyedSubtree` is specific to this use case we should use instead of Container.