### PR TITLE
refactor: remove elses when not needed

### DIFF
--- a/example/lib/remote_api.dart
+++ b/example/lib/remote_api.dart
@@ -58,11 +58,10 @@ extension on Future<http.Response> {
   Future<R> mapFromResponse<R, T>(R Function(T) jsonParser) async {
     try {
       final response = await this;
-      if (response.statusCode == 200) {
-        return jsonParser(jsonDecode(response.body));
-      } else {
+      if (response.statusCode != 200) {
         throw GenericHttpException();
       }
+      return jsonParser(jsonDecode(response.body));
     } on SocketException {
       throw NoConnectionException();
     }

--- a/lib/src/model/paging_state.dart
+++ b/lib/src/model/paging_state.dart
@@ -41,9 +41,8 @@ class PagingState<PageKeyType, ItemType> {
 
     if (_isEmpty) {
       return PagingStatus.noItemsFound;
-    } else {
-      return PagingStatus.firstPageError;
     }
+    return PagingStatus.firstPageError;
   }
 
   @override

--- a/lib/src/ui/paged_sliver_builder.dart
+++ b/lib/src/ui/paged_sliver_builder.dart
@@ -232,9 +232,8 @@ class _PagedSliverBuilderState<PageKeyType, ItemType>
                   child: child,
                 ),
               );
-            } else {
-              return child;
             }
+            return child;
           },
         ),
       );
@@ -290,11 +289,10 @@ class _FirstPageStatusIndicatorBuilder extends StatelessWidget {
       return SliverToBoxAdapter(
         child: builder(context),
       );
-    } else {
-      return SliverFillRemaining(
-        hasScrollBody: false,
-        child: builder(context),
-      );
     }
+    return SliverFillRemaining(
+      hasScrollBody: false,
+      child: builder(context),
+    );
   }
 }

--- a/lib/src/ui/paged_sliver_grid.dart
+++ b/lib/src/ui/paged_sliver_grid.dart
@@ -155,17 +155,16 @@ class _AppendedSliverGrid extends StatelessWidget {
           appendixBuilder: appendixBuilder,
         ),
       );
-    } else {
-      return MultiSliver(children: [
-        SliverGrid(
-          gridDelegate: gridDelegate,
-          delegate: _buildSliverDelegate(),
-        ),
-        SliverToBoxAdapter(
-          child: appendixBuilder!(context),
-        ),
-      ]);
     }
+    return MultiSliver(children: [
+      SliverGrid(
+        gridDelegate: gridDelegate,
+        delegate: _buildSliverDelegate(),
+      ),
+      SliverToBoxAdapter(
+        child: appendixBuilder!(context),
+      ),
+    ]);
   }
 
   SliverChildBuilderDelegate _buildSliverDelegate({


### PR DESCRIPTION
Because it makes the code simpler.