### PR TITLE
Added prototypeItem field to PagedListView and PagedSliverList

### DIFF
--- a/lib/src/ui/paged_list_view.dart
+++ b/lib/src/ui/paged_list_view.dart
@@ -31,6 +31,7 @@ class PagedListView<PageKeyType, ItemType> extends BoxScrollView {
     // Corresponds to [BoxScrollView.padding].
     EdgeInsetsGeometry? padding,
     this.itemExtent,
+    this.prototypeItem,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
@@ -46,7 +47,11 @@ class PagedListView<PageKeyType, ItemType> extends BoxScrollView {
     // Corresponds to [ScrollView.clipBehavior]
     Clip clipBehavior = Clip.hardEdge,
     Key? key,
-  })  : _separatorBuilder = null,
+  })  : assert(
+          itemExtent == null ||prototypeItem == null, 
+          'You can only pass itemExtent or prototypeItem, not both',
+        ),
+        _separatorBuilder = null,
         _shrinkWrapFirstPageIndicators = shrinkWrap,
         super(
           key: key,
@@ -83,6 +88,7 @@ class PagedListView<PageKeyType, ItemType> extends BoxScrollView {
     // Corresponds to [BoxScrollView.padding].
     EdgeInsetsGeometry? padding,
     this.itemExtent,
+    this.prototypeItem,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
@@ -98,7 +104,11 @@ class PagedListView<PageKeyType, ItemType> extends BoxScrollView {
     // Corresponds to [ScrollView.clipBehavior]
     Clip clipBehavior = Clip.hardEdge,
     Key? key,
-  })  : _shrinkWrapFirstPageIndicators = shrinkWrap,
+  })  : assert(
+          itemExtent == null ||prototypeItem == null, 
+          'You can only pass itemExtent or prototypeItem, not both',
+        ),
+        _shrinkWrapFirstPageIndicators = shrinkWrap,
         _separatorBuilder = separatorBuilder,
         super(
           key: key,
@@ -134,8 +144,13 @@ class PagedListView<PageKeyType, ItemType> extends BoxScrollView {
   /// Corresponds to [SliverChildBuilderDelegate.addSemanticIndexes].
   final bool addSemanticIndexes;
 
-  /// Corresponds to [ListView.itemExtent].
+    /// Corresponds to [SliverFixedExtentList.itemExtent].
+  /// If this is not null, [prototypeItem] must be null, and vice versa.
   final double? itemExtent;
+
+  /// Corresponds to [SliverPrototypeExtentList.prototypeItem].
+  /// If this is not null, [itemExtent] must be null, and vice versa.
+  final Widget? prototypeItem;
 
   /// Corresponds to [PagedSliverList.shrinkWrapFirstPageIndicators].
   final bool _shrinkWrapFirstPageIndicators;

--- a/lib/src/ui/paged_sliver_list.dart
+++ b/lib/src/ui/paged_sliver_list.dart
@@ -23,10 +23,15 @@ class PagedSliverList<PageKeyType, ItemType> extends StatelessWidget {
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
     this.itemExtent,
+    this.prototypeItem,
     this.semanticIndexCallback,
     this.shrinkWrapFirstPageIndicators = false,
     Key? key,
-  })  : _separatorBuilder = null,
+  })  : assert(
+          itemExtent ==null ||prototypeItem==null, 
+          'You can only pass itemExtent or prototypeItem, not both',
+        ),
+        _separatorBuilder = null,
         super(key: key);
 
   const PagedSliverList.separated({
@@ -37,10 +42,15 @@ class PagedSliverList<PageKeyType, ItemType> extends StatelessWidget {
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
     this.itemExtent,
+    this.prototypeItem,
     this.semanticIndexCallback,
     this.shrinkWrapFirstPageIndicators = false,
     Key? key,
-  })  : _separatorBuilder = separatorBuilder,
+  })  : assert(
+          itemExtent == null ||prototypeItem == null, 
+          'You can only pass itemExtent or prototypeItem, not both',
+        ),
+        _separatorBuilder = separatorBuilder,
         super(key: key);
 
   /// Corresponds to [PagedSliverBuilder.pagingController].
@@ -65,7 +75,12 @@ class PagedSliverList<PageKeyType, ItemType> extends StatelessWidget {
   final SemanticIndexCallback? semanticIndexCallback;
 
   /// Corresponds to [SliverFixedExtentList.itemExtent].
+  /// If this is not null, [prototypeItem] must be null, and vice versa.
   final double? itemExtent;
+
+  /// Corresponds to [SliverPrototypeExtentList.prototypeItem].
+  /// If this is not null, [itemExtent] must be null, and vice versa.
+  final Widget? prototypeItem;
 
   /// Corresponds to [PagedSliverBuilder.shrinkWrapFirstPageIndicators].
   final bool shrinkWrapFirstPageIndicators;
@@ -124,13 +139,17 @@ class PagedSliverList<PageKeyType, ItemType> extends StatelessWidget {
 
     final itemExtent = this.itemExtent;
 
-    return (itemExtent == null || _separatorBuilder != null)
+    return ((itemExtent == null && prototypeItem == null) || _separatorBuilder != null)
         ? SliverList(
             delegate: delegate,
           )
-        : SliverFixedExtentList(
+        : (itemExtent != null)? 
+        SliverFixedExtentList(
             delegate: delegate,
             itemExtent: itemExtent,
+          ): SliverPrototypeExtentList(
+            delegate: delegate,
+            prototypeItem: prototypeItem!,
           );
   }
 


### PR DESCRIPTION
Adds parity with ListView.prototypeItem and SliverPrototypeExtent by adding parameter fields to PagedSliverList and PagedListView, thus providing support for PagedListViews and PagedSliverLists to use prototype items to size their children.