### PR TITLE
Update this change for null exception during complication

### DIFF
--- a/lib/src/ui/paged_sliver_builder.dart
+++ b/lib/src/ui/paged_sliver_builder.dart
@@ -251,7 +251,7 @@ class _PagedSliverBuilderState<PageKeyType, ItemType>
 
       if (_hasNextPage && isBuildingTriggerIndexItem) {
         // Schedules the request for the end of this frame.
-        WidgetsBinding.instance.addPostFrameCallback((_) {
+        WidgetsBinding.instance?.addPostFrameCallback((_) {
           _pagingController.notifyPageRequestListeners(_nextKey!);
         });
         _hasRequestedNextPage = true;


### PR DESCRIPTION
Flutter Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null