### PR TITLE
State noItemsFound and firstPageError not working properly

### DIFF
--- a/lib/src/model/paging_state.dart
+++ b/lib/src/model/paging_state.dart
@@ -90,5 +90,5 @@ class PagingState<PageKeyType, ItemType> {
 
   bool get _hasSubsequentPageError => _isListingUnfinished && _hasError;
 
-  bool get _isEmpty => _itemCount != null && _itemCount == 0;
+  bool get _isEmpty => _itemCount != null && _itemCount == 0 && !_hasError;
 }


### PR DESCRIPTION
Example: Db is returning empty list not null.

I think in _isEmpty should also be checking if !_hasError