### PR TITLE
feat: create PagedSliverMasonryGrid

### DIFF
--- a/lib/infinite_scroll_pagination.dart
+++ b/lib/infinite_scroll_pagination.dart
@@ -9,3 +9,4 @@ export 'src/widgets/layouts/paged_masonry_grid_view.dart';
 export 'src/widgets/layouts/paged_page_view.dart';
 export 'src/widgets/layouts/paged_sliver_grid.dart';
 export 'src/widgets/layouts/paged_sliver_list.dart';
+export 'src/widgets/layouts/paged_sliver_masonry_grid.dart';

--- a/lib/src/utils/appended_sliver_grid.dart
+++ b/lib/src/utils/appended_sliver_grid.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/widgets.dart';
+import 'package:sliver_tools/sliver_tools.dart';
+
+import 'appended_sliver_child_builder_delegate.dart';
+
+typedef SliverGridBuilder = SliverWithKeepAliveWidget Function(
+  int childCount,
+  SliverChildDelegate delegate,
+);
+
+class AppendedSliverGrid extends StatelessWidget {
+  const AppendedSliverGrid({
+    required this.itemBuilder,
+    required this.itemCount,
+    required this.sliverGridBuilder,
+    this.showAppendixAsGridChild = true,
+    this.appendixBuilder,
+    this.addAutomaticKeepAlives = true,
+    this.addRepaintBoundaries = true,
+    this.addSemanticIndexes = true,
+    Key? key,
+  }) : super(key: key);
+
+  final IndexedWidgetBuilder itemBuilder;
+  final int itemCount;
+  final SliverGridBuilder sliverGridBuilder;
+  final bool showAppendixAsGridChild;
+  final WidgetBuilder? appendixBuilder;
+  final bool addAutomaticKeepAlives;
+  final bool addRepaintBoundaries;
+  final bool addSemanticIndexes;
+
+  @override
+  Widget build(BuildContext context) {
+    final appendixBuilder = this.appendixBuilder;
+
+    return MultiSliver(
+      children: [
+        sliverGridBuilder(
+          itemCount +
+              (showAppendixAsGridChild && appendixBuilder != null ? 1 : 0),
+          _buildSliverDelegate(
+            appendixBuilder: showAppendixAsGridChild ? appendixBuilder : null,
+          ),
+        ),
+        if (!showAppendixAsGridChild)
+          SliverToBoxAdapter(
+            child: appendixBuilder?.call(context),
+          ),
+      ],
+    );
+  }
+
+  SliverChildBuilderDelegate _buildSliverDelegate({
+    WidgetBuilder? appendixBuilder,
+  }) =>
+      AppendedSliverChildBuilderDelegate(
+        builder: itemBuilder,
+        childCount: itemCount,
+        appendixBuilder: appendixBuilder,
+        addAutomaticKeepAlives: addAutomaticKeepAlives,
+        addRepaintBoundaries: addRepaintBoundaries,
+        addSemanticIndexes: addSemanticIndexes,
+      );
+}

--- a/lib/src/widgets/layouts/paged_masonry_grid_view.dart
+++ b/lib/src/widgets/layouts/paged_masonry_grid_view.dart
@@ -2,40 +2,50 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
-import 'package:infinite_scroll_pagination/src/utils/appended_sliver_child_builder_delegate.dart';
-
-typedef SliverSimpleGridDelegateBuilder = SliverSimpleGridDelegate Function(
-  int childCount,
-);
 
 /// A [MasonryGridView] with pagination capabilities.
 ///
 /// You can also see this as a [PagedGridView] that supports rows of varying
 /// sizes.
 ///
-/// This is a wrapper around the [flutter_staggered_grid_view](https://pub.dev/packages/flutter_staggered_grid_view)
-/// package. For more info on how to build staggered grids, check out the
+/// This is a wrapper around the [MasonryGridView]
+/// from the [flutter_staggered_grid_view](https://pub.dev/packages/flutter_staggered_grid_view) package.
+/// For more info on how to build staggered grids, check out the
 /// referred package's documentation and examples.
-class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
+class PagedMasonryGridView<PageKeyType, ItemType> extends BoxScrollView {
   const PagedMasonryGridView({
     required this.pagingController,
     required this.builderDelegate,
     required this.gridDelegateBuilder,
-    this.scrollDirection = Axis.vertical,
-    this.reverse = false,
+    // Matches [ScrollView.scrollDirection].
+    Axis scrollDirection = Axis.vertical,
+    // Matches [ScrollView.reverse].
+    bool reverse = false,
+    // Matches [ScrollView.primary].
+    bool? primary,
+    // Matches [ScrollView.physics].
+    ScrollPhysics? physics,
     this.scrollController,
-    this.primary,
-    this.physics,
-    this.padding,
     this.mainAxisSpacing = 0.0,
     this.crossAxisSpacing = 0.0,
-    this.cacheExtent,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
-    this.restorationId,
-    this.clipBehavior = Clip.hardEdge,
+    // Matches [ScrollView.cacheExtent].
+    double? cacheExtent,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    // Matches [ScrollView.dragStartBehavior].
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    // Matches [ScrollView.keyboardDismissBehavior].
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
+    // Matches [ScrollView.restorationId].
+    String? restorationId,
+    // Matches [ScrollView.clipBehavior].
+    Clip clipBehavior = Clip.hardEdge,
     // Matches [ScrollView.shrinkWrap].
     bool shrinkWrap = false,
+    // Matches [BoxScrollView.padding].
+    EdgeInsetsGeometry? padding,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
@@ -43,6 +53,18 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
   })  : _shrinkWrapFirstPageIndicators = shrinkWrap,
         super(
           key: key,
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: scrollController,
+          primary: primary,
+          physics: physics,
+          shrinkWrap: shrinkWrap,
+          padding: padding,
+          cacheExtent: cacheExtent,
+          dragStartBehavior: dragStartBehavior,
+          keyboardDismissBehavior: keyboardDismissBehavior,
+          restorationId: restorationId,
+          clipBehavior: clipBehavior,
         );
 
   /// Equivalent to [MasonryGridView.count].
@@ -50,21 +72,34 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
     required this.pagingController,
     required this.builderDelegate,
     required int crossAxisCount,
-    this.scrollDirection = Axis.vertical,
-    this.reverse = false,
+    Axis scrollDirection = Axis.vertical,
+    // Matches [ScrollView.reverse].
+    bool reverse = false,
+    // Matches [ScrollView.primary].
+    bool? primary,
+    // Matches [ScrollView.physics].
+    ScrollPhysics? physics,
     this.scrollController,
-    this.primary,
-    this.physics,
-    this.padding,
     this.mainAxisSpacing = 0.0,
     this.crossAxisSpacing = 0.0,
-    this.cacheExtent,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
-    this.restorationId,
-    this.clipBehavior = Clip.hardEdge,
+    // Matches [ScrollView.cacheExtent].
+    double? cacheExtent,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    // Matches [ScrollView.dragStartBehavior].
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    // Matches [ScrollView.keyboardDismissBehavior].
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
+    // Matches [ScrollView.restorationId].
+    String? restorationId,
+    // Matches [ScrollView.clipBehavior].
+    Clip clipBehavior = Clip.hardEdge,
     // Matches [ScrollView.shrinkWrap].
     bool shrinkWrap = false,
+    // Matches [BoxScrollView.padding].
+    EdgeInsetsGeometry? padding,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
@@ -76,6 +111,18 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
                 )),
         super(
           key: key,
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: scrollController,
+          primary: primary,
+          physics: physics,
+          shrinkWrap: shrinkWrap,
+          padding: padding,
+          cacheExtent: cacheExtent,
+          dragStartBehavior: dragStartBehavior,
+          keyboardDismissBehavior: keyboardDismissBehavior,
+          restorationId: restorationId,
+          clipBehavior: clipBehavior,
         );
 
   /// Equivalent to [MasonryGridView.extent].
@@ -83,21 +130,34 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
     required this.pagingController,
     required this.builderDelegate,
     required double maxCrossAxisExtent,
-    this.scrollDirection = Axis.vertical,
-    this.reverse = false,
+    Axis scrollDirection = Axis.vertical,
+    // Matches [ScrollView.reverse].
+    bool reverse = false,
+    // Matches [ScrollView.primary].
+    bool? primary,
+    // Matches [ScrollView.physics].
+    ScrollPhysics? physics,
     this.scrollController,
-    this.primary,
-    this.physics,
-    this.padding,
     this.mainAxisSpacing = 0.0,
     this.crossAxisSpacing = 0.0,
-    this.cacheExtent,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
-    this.restorationId,
-    this.clipBehavior = Clip.hardEdge,
+    // Matches [ScrollView.cacheExtent].
+    double? cacheExtent,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    // Matches [ScrollView.dragStartBehavior].
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    // Matches [ScrollView.keyboardDismissBehavior].
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
+    // Matches [ScrollView.restorationId].
+    String? restorationId,
+    // Matches [ScrollView.clipBehavior].
+    Clip clipBehavior = Clip.hardEdge,
     // Matches [ScrollView.shrinkWrap].
     bool shrinkWrap = false,
+    // Matches [BoxScrollView.padding].
+    EdgeInsetsGeometry? padding,
     this.addAutomaticKeepAlives = true,
     this.addRepaintBoundaries = true,
     this.addSemanticIndexes = true,
@@ -109,6 +169,18 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
                 )),
         super(
           key: key,
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: scrollController,
+          primary: primary,
+          physics: physics,
+          shrinkWrap: shrinkWrap,
+          padding: padding,
+          cacheExtent: cacheExtent,
+          dragStartBehavior: dragStartBehavior,
+          keyboardDismissBehavior: keyboardDismissBehavior,
+          restorationId: restorationId,
+          clipBehavior: clipBehavior,
         );
 
   /// Matches [PagedLayoutBuilder.pagingController].
@@ -121,42 +193,12 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
   /// that a [SliverSimpleGridDelegate] can be returned.
   final SliverSimpleGridDelegateBuilder gridDelegateBuilder;
 
-  /// Matches [ScrollView.scrollDirection]
-  final Axis scrollDirection;
-
-  /// Matches [ScrollView.reverse]
-  final bool reverse;
-
   /// Matches [ScrollView.controller]
   final ScrollController? scrollController;
-
-  /// Matches [ScrollView.primary].
-  final bool? primary;
-
-  /// Matches [ScrollView.physics].
-  final ScrollPhysics? physics;
-
-  /// Matches [BoxScrollView.padding].
-  final EdgeInsetsGeometry? padding;
 
   final double mainAxisSpacing;
 
   final double crossAxisSpacing;
-
-  /// Matches [ScrollView.cacheExtent].
-  final double? cacheExtent;
-
-  /// Matches [ScrollView.dragStartBehavior].
-  final DragStartBehavior dragStartBehavior;
-
-  /// Matches [ScrollView.keyboardDismissBehavior].
-  final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
-
-  /// Matches [ScrollView.restorationId].
-  final String? restorationId;
-
-  /// Matches [ScrollView.clipBehavior].
-  final Clip clipBehavior;
 
   /// Matches [SliverChildBuilderDelegate.addAutomaticKeepAlives].
   final bool addAutomaticKeepAlives;
@@ -167,111 +209,33 @@ class PagedMasonryGridView<PageKeyType, ItemType> extends StatelessWidget {
   /// Matches [SliverChildBuilderDelegate.addSemanticIndexes].
   final bool addSemanticIndexes;
 
+  /// Matches [PagedSliverGrid.showNewPageProgressIndicatorAsGridChild].
+  final bool showNewPageProgressIndicatorAsGridChild;
+
+  /// Matches [PagedSliverGrid.showNewPageErrorIndicatorAsGridChild].
+  final bool showNewPageErrorIndicatorAsGridChild;
+
+  /// Matches [PagedSliverGrid.showNoMoreItemsIndicatorAsGridChild].
+  final bool showNoMoreItemsIndicatorAsGridChild;
+
   /// Matches [PagedSliverGrid.shrinkWrapFirstPageIndicators].
   final bool _shrinkWrapFirstPageIndicators;
 
   @override
-  Widget build(BuildContext context) =>
-      PagedLayoutBuilder<PageKeyType, ItemType>(
-        layoutProtocol: PagedLayoutProtocol.box,
-        pagingController: pagingController,
+  Widget buildChildLayout(BuildContext context) =>
+      PagedMasonrySliverGrid<PageKeyType, ItemType>(
         builderDelegate: builderDelegate,
+        pagingController: pagingController,
+        gridDelegateBuilder: gridDelegateBuilder,
+        addAutomaticKeepAlives: addAutomaticKeepAlives,
+        addRepaintBoundaries: addRepaintBoundaries,
+        addSemanticIndexes: addSemanticIndexes,
+        showNewPageProgressIndicatorAsGridChild:
+            showNewPageProgressIndicatorAsGridChild,
+        showNewPageErrorIndicatorAsGridChild:
+            showNewPageErrorIndicatorAsGridChild,
+        showNoMoreItemsIndicatorAsGridChild:
+            showNoMoreItemsIndicatorAsGridChild,
         shrinkWrapFirstPageIndicators: _shrinkWrapFirstPageIndicators,
-        completedListingBuilder: (
-          context,
-          itemBuilder,
-          itemCount,
-          noMoreItemsIndicatorBuilder,
-        ) =>
-            MasonryGridView.custom(
-          scrollDirection: scrollDirection,
-          reverse: reverse,
-          controller: scrollController,
-          primary: primary,
-          physics: physics,
-          padding: padding,
-          mainAxisSpacing: mainAxisSpacing,
-          crossAxisSpacing: crossAxisSpacing,
-          cacheExtent: cacheExtent,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-          restorationId: restorationId,
-          clipBehavior: clipBehavior,
-          gridDelegate: gridDelegateBuilder(
-            itemCount + (noMoreItemsIndicatorBuilder == null ? 0 : 1),
-          ),
-          childrenDelegate: AppendedSliverChildBuilderDelegate(
-            builder: itemBuilder,
-            childCount: itemCount,
-            appendixBuilder: noMoreItemsIndicatorBuilder,
-            addAutomaticKeepAlives: addAutomaticKeepAlives,
-            addRepaintBoundaries: addRepaintBoundaries,
-            addSemanticIndexes: addSemanticIndexes,
-          ),
-        ),
-        loadingListingBuilder: (
-          context,
-          itemBuilder,
-          itemCount,
-          progressIndicatorBuilder,
-        ) =>
-            MasonryGridView.custom(
-          scrollDirection: scrollDirection,
-          reverse: reverse,
-          controller: scrollController,
-          primary: primary,
-          physics: physics,
-          padding: padding,
-          mainAxisSpacing: mainAxisSpacing,
-          crossAxisSpacing: crossAxisSpacing,
-          cacheExtent: cacheExtent,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-          restorationId: restorationId,
-          clipBehavior: clipBehavior,
-          gridDelegate: gridDelegateBuilder(
-            itemCount + 1,
-          ),
-          childrenDelegate: AppendedSliverChildBuilderDelegate(
-            builder: itemBuilder,
-            childCount: itemCount,
-            appendixBuilder: progressIndicatorBuilder,
-            addAutomaticKeepAlives: addAutomaticKeepAlives,
-            addRepaintBoundaries: addRepaintBoundaries,
-            addSemanticIndexes: addSemanticIndexes,
-          ),
-        ),
-        errorListingBuilder: (
-          context,
-          itemBuilder,
-          itemCount,
-          errorIndicatorBuilder,
-        ) =>
-            MasonryGridView.custom(
-          scrollDirection: scrollDirection,
-          reverse: reverse,
-          controller: scrollController,
-          primary: primary,
-          physics: physics,
-          padding: padding,
-          mainAxisSpacing: mainAxisSpacing,
-          crossAxisSpacing: crossAxisSpacing,
-          cacheExtent: cacheExtent,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-          restorationId: restorationId,
-          clipBehavior: clipBehavior,
-          gridDelegate: gridDelegateBuilder(
-            itemCount + 1,
-          ),
-          childrenDelegate: AppendedSliverChildBuilderDelegate(
-            builder: itemBuilder,
-            childCount: itemCount,
-            appendixBuilder: errorIndicatorBuilder,
-            addAutomaticKeepAlives: addAutomaticKeepAlives,
-            addRepaintBoundaries: addRepaintBoundaries,
-            addSemanticIndexes: addSemanticIndexes,
-          ),
-        ),
       );
 }

--- a/lib/src/widgets/layouts/paged_sliver_grid.dart
+++ b/lib/src/widgets/layouts/paged_sliver_grid.dart
@@ -1,15 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:infinite_scroll_pagination/src/core/paged_child_builder_delegate.dart';
 import 'package:infinite_scroll_pagination/src/core/paging_controller.dart';
-import 'package:infinite_scroll_pagination/src/utils/appended_sliver_child_builder_delegate.dart';
+import 'package:infinite_scroll_pagination/src/utils/appended_sliver_grid.dart';
 import 'package:infinite_scroll_pagination/src/widgets/helpers/paged_layout_builder.dart';
 import 'package:infinite_scroll_pagination/src/widgets/layouts/paged_grid_view.dart';
-import 'package:sliver_tools/sliver_tools.dart';
-
-typedef SliverGridBuilder = SliverWithKeepAliveWidget Function(
-  int childCount,
-  SliverChildDelegate delegate,
-);
 
 /// Paged [SliverGrid] with progress and error indicators displayed as the last
 /// item.
@@ -84,7 +78,7 @@ class PagedSliverGrid<PageKeyType, ItemType> extends StatelessWidget {
           itemCount,
           noMoreItemsIndicatorBuilder,
         ) =>
-            _AppendedSliverGrid(
+            AppendedSliverGrid(
           sliverGridBuilder: (_, delegate) => SliverGrid(
             delegate: delegate,
             gridDelegate: gridDelegate,
@@ -103,7 +97,7 @@ class PagedSliverGrid<PageKeyType, ItemType> extends StatelessWidget {
           itemCount,
           progressIndicatorBuilder,
         ) =>
-            _AppendedSliverGrid(
+            AppendedSliverGrid(
           sliverGridBuilder: (_, delegate) => SliverGrid(
             delegate: delegate,
             gridDelegate: gridDelegate,
@@ -122,7 +116,7 @@ class PagedSliverGrid<PageKeyType, ItemType> extends StatelessWidget {
           itemCount,
           errorIndicatorBuilder,
         ) =>
-            _AppendedSliverGrid(
+            AppendedSliverGrid(
           sliverGridBuilder: (_, delegate) => SliverGrid(
             delegate: delegate,
             gridDelegate: gridDelegate,
@@ -136,66 +130,5 @@ class PagedSliverGrid<PageKeyType, ItemType> extends StatelessWidget {
           addRepaintBoundaries: addRepaintBoundaries,
         ),
         shrinkWrapFirstPageIndicators: shrinkWrapFirstPageIndicators,
-      );
-}
-
-class _AppendedSliverGrid extends StatelessWidget {
-  const _AppendedSliverGrid({
-    required this.itemBuilder,
-    required this.itemCount,
-    required this.sliverGridBuilder,
-    this.showAppendixAsGridChild = true,
-    this.appendixBuilder,
-    this.addAutomaticKeepAlives = true,
-    this.addRepaintBoundaries = true,
-    this.addSemanticIndexes = true,
-    Key? key,
-  }) : super(key: key);
-
-  final IndexedWidgetBuilder itemBuilder;
-  final int itemCount;
-  final SliverGridBuilder sliverGridBuilder;
-  final bool showAppendixAsGridChild;
-  final WidgetBuilder? appendixBuilder;
-  final bool addAutomaticKeepAlives;
-  final bool addRepaintBoundaries;
-  final bool addSemanticIndexes;
-
-  @override
-  Widget build(BuildContext context) {
-    final appendixBuilder = this.appendixBuilder;
-
-    if (showAppendixAsGridChild == true || appendixBuilder == null) {
-      return sliverGridBuilder(
-        itemCount + (appendixBuilder == null ? 0 : 1),
-        _buildSliverDelegate(
-          appendixBuilder: appendixBuilder,
-        ),
-      );
-    } else {
-      return MultiSliver(
-        children: [
-          sliverGridBuilder(
-            itemCount,
-            _buildSliverDelegate(),
-          ),
-          SliverToBoxAdapter(
-            child: appendixBuilder(context),
-          ),
-        ],
-      );
-    }
-  }
-
-  SliverChildBuilderDelegate _buildSliverDelegate({
-    WidgetBuilder? appendixBuilder,
-  }) =>
-      AppendedSliverChildBuilderDelegate(
-        builder: itemBuilder,
-        childCount: itemCount,
-        appendixBuilder: appendixBuilder,
-        addAutomaticKeepAlives: addAutomaticKeepAlives,
-        addRepaintBoundaries: addRepaintBoundaries,
-        addSemanticIndexes: addSemanticIndexes,
       );
 }

--- a/lib/src/widgets/layouts/paged_sliver_masonry_grid.dart
+++ b/lib/src/widgets/layouts/paged_sliver_masonry_grid.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:infinite_scroll_pagination/src/utils/appended_sliver_grid.dart';
+
+typedef SliverSimpleGridDelegateBuilder = SliverSimpleGridDelegate Function(
+  int childCount,
+);
+
+/// A [PagedMasonrySliverGrid] with pagination capabilities.
+///
+/// You can also see this as a [PagedSliverGrid] that supports rows of varying
+/// sizes.
+///
+/// This is a wrapper around the [SliverMasonryGrid]
+/// from the [flutter_staggered_grid_view](https://pub.dev/packages/flutter_staggered_grid_view) package.
+/// For more info on how to build staggered grids, check out the
+/// referred package's documentation and examples.
+class PagedMasonrySliverGrid<PageKeyType, ItemType> extends StatelessWidget {
+  const PagedMasonrySliverGrid({
+    required this.pagingController,
+    required this.builderDelegate,
+    required this.gridDelegateBuilder,
+    this.mainAxisSpacing = 0,
+    this.crossAxisSpacing = 0,
+    this.addAutomaticKeepAlives = true,
+    this.addRepaintBoundaries = true,
+    this.addSemanticIndexes = true,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    this.shrinkWrapFirstPageIndicators = false,
+    Key? key,
+  }) : super(
+          key: key,
+        );
+
+  /// Equivalent to [SliverMasonryGrid.count].
+  PagedMasonrySliverGrid.count({
+    required this.pagingController,
+    required this.builderDelegate,
+    required int crossAxisCount,
+    this.mainAxisSpacing = 0,
+    this.crossAxisSpacing = 0,
+    this.addAutomaticKeepAlives = true,
+    this.addRepaintBoundaries = true,
+    this.addSemanticIndexes = true,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    this.shrinkWrapFirstPageIndicators = false,
+    Key? key,
+  })  : gridDelegateBuilder =
+            ((childCount) => SliverSimpleGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: crossAxisCount,
+                )),
+        super(
+          key: key,
+        );
+
+  /// Equivalent to [SliverMasonryGrid.extent].
+  PagedMasonrySliverGrid.extent({
+    required this.pagingController,
+    required this.builderDelegate,
+    required double maxCrossAxisExtent,
+    this.mainAxisSpacing = 0,
+    this.crossAxisSpacing = 0,
+    this.addAutomaticKeepAlives = true,
+    this.addRepaintBoundaries = true,
+    this.addSemanticIndexes = true,
+    this.showNewPageProgressIndicatorAsGridChild = true,
+    this.showNewPageErrorIndicatorAsGridChild = true,
+    this.showNoMoreItemsIndicatorAsGridChild = true,
+    this.shrinkWrapFirstPageIndicators = false,
+    Key? key,
+  })  : gridDelegateBuilder =
+            ((childCount) => SliverSimpleGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: maxCrossAxisExtent,
+                )),
+        super(
+          key: key,
+        );
+
+  /// Matches [PagedLayoutBuilder.pagingController].
+  final PagingController<PageKeyType, ItemType> pagingController;
+
+  /// Matches [PagedLayoutBuilder.builderDelegate].
+  final PagedChildBuilderDelegate<ItemType> builderDelegate;
+
+  /// Provides the adjusted child count (based on the pagination status) so
+  /// that a [SliverSimpleGridDelegate] can be returned.
+  final SliverSimpleGridDelegateBuilder gridDelegateBuilder;
+
+  /// Matches [SliverChildBuilderDelegate.addAutomaticKeepAlives].
+  final bool addAutomaticKeepAlives;
+
+  /// Matches [SliverChildBuilderDelegate.addRepaintBoundaries].
+  final bool addRepaintBoundaries;
+
+  /// Matches [SliverChildBuilderDelegate.addSemanticIndexes].
+  final bool addSemanticIndexes;
+
+  /// Matches [PagedSliverGrid.showNewPageProgressIndicatorAsGridChild].
+  final bool showNewPageProgressIndicatorAsGridChild;
+
+  /// Matches [PagedSliverGrid.showNewPageErrorIndicatorAsGridChild].
+  final bool showNewPageErrorIndicatorAsGridChild;
+
+  /// Matches [PagedSliverGrid.showNoMoreItemsIndicatorAsGridChild].
+  final bool showNoMoreItemsIndicatorAsGridChild;
+
+  /// Matches [PagedLayoutBuilder.shrinkWrapFirstPageIndicators].
+  final bool shrinkWrapFirstPageIndicators;
+
+  /// Matches [SliverMasonryGrid.mainAxisSpacing].
+  final double mainAxisSpacing;
+
+  /// Matches [SliverMasonryGrid.mainAxisSpacing].
+  final double crossAxisSpacing;
+
+  @override
+  Widget build(BuildContext context) =>
+      PagedLayoutBuilder<PageKeyType, ItemType>(
+        layoutProtocol: PagedLayoutProtocol.sliver,
+        pagingController: pagingController,
+        builderDelegate: builderDelegate,
+        completedListingBuilder: (
+          context,
+          itemBuilder,
+          itemCount,
+          noMoreItemsIndicatorBuilder,
+        ) =>
+            AppendedSliverGrid(
+          sliverGridBuilder: (childCount, delegate) => SliverMasonryGrid(
+            delegate: delegate,
+            gridDelegate: gridDelegateBuilder(childCount),
+            mainAxisSpacing: mainAxisSpacing,
+            crossAxisSpacing: crossAxisSpacing,
+          ),
+          itemBuilder: itemBuilder,
+          itemCount: itemCount,
+          appendixBuilder: noMoreItemsIndicatorBuilder,
+          showAppendixAsGridChild: showNoMoreItemsIndicatorAsGridChild,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addSemanticIndexes: addSemanticIndexes,
+          addRepaintBoundaries: addRepaintBoundaries,
+        ),
+        loadingListingBuilder: (
+          context,
+          itemBuilder,
+          itemCount,
+          progressIndicatorBuilder,
+        ) =>
+            AppendedSliverGrid(
+          sliverGridBuilder: (childCount, delegate) => SliverMasonryGrid(
+            delegate: delegate,
+            gridDelegate: gridDelegateBuilder(childCount),
+            mainAxisSpacing: mainAxisSpacing,
+            crossAxisSpacing: crossAxisSpacing,
+          ),
+          itemBuilder: itemBuilder,
+          itemCount: itemCount,
+          appendixBuilder: progressIndicatorBuilder,
+          showAppendixAsGridChild: showNewPageProgressIndicatorAsGridChild,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addSemanticIndexes: addSemanticIndexes,
+          addRepaintBoundaries: addRepaintBoundaries,
+        ),
+        errorListingBuilder: (
+          context,
+          itemBuilder,
+          itemCount,
+          errorIndicatorBuilder,
+        ) =>
+            AppendedSliverGrid(
+          sliverGridBuilder: (childCount, delegate) => SliverMasonryGrid(
+            delegate: delegate,
+            gridDelegate: gridDelegateBuilder(childCount),
+            mainAxisSpacing: mainAxisSpacing,
+            crossAxisSpacing: crossAxisSpacing,
+          ),
+          itemBuilder: itemBuilder,
+          itemCount: itemCount,
+          appendixBuilder: errorIndicatorBuilder,
+          showAppendixAsGridChild: showNewPageErrorIndicatorAsGridChild,
+          addAutomaticKeepAlives: addAutomaticKeepAlives,
+          addSemanticIndexes: addSemanticIndexes,
+          addRepaintBoundaries: addRepaintBoundaries,
+        ),
+        shrinkWrapFirstPageIndicators: shrinkWrapFirstPageIndicators,
+      );
+}


### PR DESCRIPTION
I added `PagedSliverMasonryGrid` and rewrote `PagedMasonryGrid` to use it internally.

To facilitate this change, I moved `_AppendedSliverGrid` into its own file.
`SliverMasonryGrid`  is very similar to `SliverGrid` but not the same, so reusing this felt right.
I imagine if we implement other wrappers around the new custom staggered grid view types, this will also come in handy.

All tests pass as usual and I did not add new ones as `PagedMasonrySliverGrid` is tested through `PagedMasonryGridView` and I have seen that `PagedSliverGrid` does not have tests at the moment either. 

I have reverted `PagedMasonryGridView` to a `BoxScrollView` so that it is consistent with other paged sliver wrappers and can be used with [`pull_to_refresh`](https://pub.dev/packages/pull_to_refresh).