### PR TITLE
Fix throwing null errors after disposal in release mode

### DIFF
--- a/lib/src/core/paging_controller.dart
+++ b/lib/src/core/paging_controller.dart
@@ -148,7 +148,7 @@ class PagingController<PageKeyType, ItemType>
   /// Listeners can be removed with [removeStatusListener].
   void addStatusListener(PagingStatusListener listener) {
     assert(_debugAssertNotDisposed());
-    _statusListeners!.add(listener);
+    _statusListeners?.add(listener);
   }
 
   /// Stops calling the listener every time the status of the pagination
@@ -157,7 +157,7 @@ class PagingController<PageKeyType, ItemType>
   /// Listeners can be added with [addStatusListener].
   void removeStatusListener(PagingStatusListener listener) {
     assert(_debugAssertNotDisposed());
-    _statusListeners!.remove(listener);
+    _statusListeners?.remove(listener);
   }
 
   /// Calls all the status listeners.
@@ -167,7 +167,7 @@ class PagingController<PageKeyType, ItemType>
   void notifyStatusListeners(PagingStatus status) {
     assert(_debugAssertNotDisposed());
 
-    if (_statusListeners!.isEmpty) {
+    if (_statusListeners?.isEmpty ?? true) {
       return;
     }
 
@@ -184,7 +184,7 @@ class PagingController<PageKeyType, ItemType>
   /// Listeners can be removed with [removePageRequestListener].
   void addPageRequestListener(PageRequestListener<PageKeyType> listener) {
     assert(_debugAssertNotDisposed());
-    _pageRequestListeners!.add(listener);
+    _pageRequestListeners?.add(listener);
   }
 
   /// Stops calling the listener every time new items are needed.
@@ -192,7 +192,7 @@ class PagingController<PageKeyType, ItemType>
   /// Listeners can be added with [addPageRequestListener].
   void removePageRequestListener(PageRequestListener<PageKeyType> listener) {
     assert(_debugAssertNotDisposed());
-    _pageRequestListeners!.remove(listener);
+    _pageRequestListeners?.remove(listener);
   }
 
   /// Calls all the page request listeners.


### PR DESCRIPTION
Fixes the issue from #256 with the same solution as #246 