### PR TITLE
fix: error when erronously calling notifyStatusListeners in release mode

### DIFF
--- a/lib/src/core/paging_controller.dart
+++ b/lib/src/core/paging_controller.dart
@@ -167,7 +167,7 @@ class PagingController<PageKeyType, ItemType>
   void notifyStatusListeners(PagingStatus status) {
     assert(_debugAssertNotDisposed());
 
-    if (_statusListeners!.isEmpty) {
+    if (_statusListeners?.isEmpty ?? true) {
       return;
     }
 


### PR DESCRIPTION
fixes "Null check operator used on a null value" error reusing the same approach used in pull request #246.

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value
#00 pc 0x3ccf67 it.andreafailli.fuskiapp (PagingController.notifyStatusListeners [paging_controller.dart:170]) (BuildId: 3aa6f915f34fd0ca1e48b7119dad02d6)
#01 pc 0x3ccf1f it.andreafailli.fuskiapp (PagingController.value= [paging_controller.dart:94]) (BuildId: 3aa6f915f34fd0ca1e48b7119dad02d6)
#02 pc 0x3cceb3 it.andreafailli.fuskiapp (PagingController.error= [paging_controller.dart:69]) (BuildId: 3aa6f915f34fd0ca1e48b7119dad02d6)
#03 pc 0x6857cf it.andreafailli.fuskiapp (_DiscoverPageState._fetchPage [discover_page.dart:71]) (BuildId: 3aa6f915f34fd0ca1e48b7119dad02d6)
```