### PR TITLE
Update new_page_error_indicator.dart

### DIFF
--- a/lib/src/widgets/helpers/default_status_indicators/new_page_error_indicator.dart
+++ b/lib/src/widgets/helpers/default_status_indicators/new_page_error_indicator.dart
@@ -11,7 +11,7 @@ class NewPageErrorIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) => InkWell(
         onTap: onTap,
-        child: const FooterTile(
+        child: FooterTile(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [


### PR DESCRIPTION
fix build ERROR in Flutter 3.7.12 environment;

```log
Pub/Cache/hosted/pub.dev/infinite_scroll_pagination-4.0.0/lib/src/widgets/helpers/default_status_indicators/new_page_error_indicator.dart:15:18: Error: Cannot invoke a non-'const' constructor where a const expression is expected.
Try using a constructor or factory that is 'const'.
          child: Column(
                 ^^^^^^
Target kernel_snapshot failed: Exception
```