### PR TITLE
Improve return type to Future<void> as method is async.

### DIFF
--- a/lib/src/core/paging_controller.dart
+++ b/lib/src/core/paging_controller.dart
@@ -51,7 +51,7 @@ class PagingController<PageKeyType, ItemType>
   /// Fetches the next page.
   ///
   /// If called while a page is fetching or no more pages are available, this method does nothing.
-  void fetchNextPage() async {
+  Future<void> fetchNextPage() async {
     // We are already loading a new page.
     if (this.operation != null) return;
 


### PR DESCRIPTION
As the title says, its a simple fix of the method type for making it able to await it in ones code.
All the tests pass.

The current way of achieving this behavior, but rather _hackily_, is like this:

```dart
await Future.value(pagingController.value.fetchNextPage() as Future<void>);
```


After this PR it should look like this:

```dart
await pagingController.value.fetchNextPage();
```