### PR TITLE
fix: dont call fetchPage when no longer mounted in addPostFrameCallback

### DIFF
--- a/lib/src/base/paged_layout_builder.dart
+++ b/lib/src/base/paged_layout_builder.dart
@@ -114,9 +114,7 @@ class _PagedLayoutBuilderState<PageKeyType, ItemType>
       // This is important to prevent recursive builds.
       () => WidgetsBinding.instance
           .addPostFrameCallback((_) {
-            if(!mounted) {
-              return;
-            }
+            if(!mounted) return;
             widget.fetchNextPage();
           });
 

--- a/lib/src/base/paged_layout_builder.dart
+++ b/lib/src/base/paged_layout_builder.dart
@@ -113,7 +113,12 @@ class _PagedLayoutBuilderState<PageKeyType, ItemType>
       // We make sure to only schedule the fetch after the current build is done.
       // This is important to prevent recursive builds.
       () => WidgetsBinding.instance
-          .addPostFrameCallback((_) => widget.fetchNextPage());
+          .addPostFrameCallback((_) {
+            if(!mounted) {
+              return;
+            }
+            widget.fetchNextPage();
+          });
 
   PagedChildBuilderDelegate<ItemType> get _builderDelegate =>
       widget.builderDelegate;


### PR DESCRIPTION
see https://github.com/EdsonBueno/infinite_scroll_pagination/issues/376